### PR TITLE
Two simple optimizations (Request animation frame and specifying keys)

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -19,20 +19,17 @@ export default Ember.Controller.extend({
   loadSamples() {
     set(this, 'model', generateData(get(this, 'model.databaseArray')));
     monitoring.renderRate.ping();
-    clear = Ember.run.later(this, 'loadSamples', 0);
-    // clear = setTimeout(this.loadSamples, 0);
+    clear = requestAnimationFrame(Ember.run.bind(this, this.loadSamples));
   },
 
   actions: {
     toggle() {
       if (get(this, 'playing')) {
-        Ember.run.cancel(clear);
-        // clearTimeout(clear);
+        cancelAnimationFrame(clear);
         clear = null;
         set(this, 'playing', false);
       } else {
         this.loadSamples();
-        // get(this, 'loadSamples')();
         set(this, 'playing', true);
       }
     }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -2,7 +2,7 @@
 
 <table class="table table-striped latest-data">
   <tbody>
-    {{#each model.databaseArray as |db|}}
+    {{#each model.databaseArray key="name" as |db|}}
       {{dbmon-database db=db}}
     {{/each}}
   </tbody>

--- a/app/templates/components/dbmon-database.hbs
+++ b/app/templates/components/dbmon-database.hbs
@@ -6,7 +6,7 @@
     {{queries.length}}
   </span>
 </td>
-{{#each topFiveQueries as |query|}}
+{{#each topFiveQueries key="key" as |query|}}
   <td class="Query {{query.className}}">
     {{query.elapsed}}
     <div class="popover left">


### PR DESCRIPTION
Due to feedback from @wycats that request animation frame was likely preferable to using timeouts to generate each iteration of the data, I've refactored the `application` controller to request and cancel animation frames in place of previously using the run loop.

In addition, I realized that I was missing a significant optimization opportunity by not specifying a key for the `each` blocks. Adding `key` parameters results in a *significant* performance boost (like...300% increase).

The weird thing is that specifying *any* key (including a random string), seems to result in the same performance boost.